### PR TITLE
fix: set exception filters after configuration has completed

### DIFF
--- a/lua/nvim-dap-exception-breakpoints/init.lua
+++ b/lua/nvim-dap-exception-breakpoints/init.lua
@@ -32,7 +32,7 @@ end
 
 -- the list of supported exception breakpoints become available when the dap is initialized
 -- therefore i read it and i set my global variables
-dap.listeners.after["initialize"]["exception_breakpoints"] = function(session, _)
+dap.listeners.after["configurationDone"]["exception_breakpoints"] = function(session, _)
 	local breakpoints_options = session.capabilities.exceptionBreakpointFilters
 
 	-- the options hasn't change since last initialization, therefore there is no need to update them


### PR DESCRIPTION
Found this while attempting to use codelldb to debug rust (via rustaceanvim) - for some reason after "initialize" the filter options (all available here: https://github.com/vadimcn/codelldb/blob/e5aef55fd68b54f9f33c7c293e0321d7f6396be8/adapter/codelldb/src/debug_session/breakpoints.rs#L407 ) were only ever "cpp_throw" and "cpp_catch", but after "configurationDone" the filter options were only "rust_panic". I _think_ this has to do with this comment https://github.com/mrcjkb/rustaceanvim/blob/0f7e844e3d82703ae8fe82b6d3ab40041b3cd9f8/lua/rustaceanvim/dap.lua#L21 but tbh idk - it seemed like this would work from the dap docs https://microsoft.github.io/debug-adapter-protocol/specification#Requests_ConfigurationDone and it does seem to